### PR TITLE
add-color-icon mixin - webkit support

### DIFF
--- a/src/stylesheets/core/mixins/_icon.scss
+++ b/src/stylesheets/core/mixins/_icon.scss
@@ -141,6 +141,10 @@
     background: none;
     background-color: if($color == currentColor, $color, color($color));
     mask: $mask-props;
+    // added to work in Chrome/webkit
+    -webkit-mask-image: url("#{$path}/usa-icons/#{$filename-base}.svg");
+    -webkit-mask-repeat: no-repeat;
+    -webkit-mask-position: center;
     @if $color-hover {
       &:hover {
         background-color: color($color-hover);


### PR DESCRIPTION

## Description

This addresses a display glitch: icons can be dropped when properties are missing due to partial support of `mask` in webkit browsers (Nov 2021).

The problem is addressed by adding webkit properties back.

An example of a dropped icon (the down arrow after "Here's how you know"):

![image](https://user-images.githubusercontent.com/1588228/143270721-8b5a26c2-52c9-409c-92b9-69dd002f0b4b.png)

Partial support of `mask` is noted here: https://caniuse.com/?search=mask

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
- [ ] Title your pull request using this format: [Website] - [UI component]: Brief statement describing what this pull request solves.
